### PR TITLE
missing an 's' in method call on DailyEmailScheduler

### DIFF
--- a/lib/tasks/daily_email.rake
+++ b/lib/tasks/daily_email.rake
@@ -2,6 +2,6 @@
 desc "Send daily email reading"
 task daily_email: :environment do
 
-  DailyEmailScheduler.set_daily_email_job
+  DailyEmailScheduler.set_daily_email_jobs
 
 end


### PR DESCRIPTION
DailyEmailScheduler has a method called "set_daily_email_jobs" which is called by the rake task daily_email.rake, however it was missing the 's' in the rake task.
