### PR TITLE
fixing sidekiq worker, had too many arguments

### DIFF
--- a/app/workers/daily_email_worker.rb
+++ b/app/workers/daily_email_worker.rb
@@ -3,7 +3,7 @@ class DailyEmailWorker
   #if there is a problem with the email we don't want the worker retrying the job
   sidekiq_options retry: false
 
-  def perform(user_reading_utc, reading, member)
+  def perform(reading, member)
     ReadingMailer.daily_reading_email(reading, member).deliver_now
   end
 


### PR DESCRIPTION
Staging was not firing emails at the scheduled time because the method was calling for three arguments (one for the scheduled time), when only two are being passed in.
