### PR TITLE
adding airbrake to track down and debug sidekiq job errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'activerecord-import'
 #gem 'chosen-rails'
 gem 'thin'
 gem 'sidekiq'
+gem 'airbrake'
 gem 'sinatra', :require => nil #required for viewing sidekiq jobs in web interface
 gem 'pickadate-rails'
 gem 'font-awesome-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,9 @@ GEM
       tzinfo (~> 1.1)
     acts_as_scriptural (0.0.3)
     addressable (2.3.8)
+    airbrake (4.2.1)
+      builder
+      multi_json
     annotate (2.6.10)
       activerecord (>= 3.2, <= 4.3)
       rake (~> 10.4)
@@ -404,6 +407,7 @@ DEPENDENCIES
   activerecord-deprecated_finders
   activerecord-import
   acts_as_scriptural (= 0.0.3)
+  airbrake
   annotate
   autoprefixer-rails
   better_errors

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,3 @@
+Airbrake.configure do |config|
+  config.api_key = '0bfcdae250c33aa08f622826818c892c'
+end


### PR DESCRIPTION
Airbrake is a service that allows you to keep track of all errors generated through sidekiq. It's a good debugging service.
Service is free for one project. At: https://biblechallenges.airbrake.io/projects/113334/groups
username: manuel.garcia@bfa.org
password: biblechallenges144K
