### PR TITLE
Fixing membership_mailer. creation_email view

### DIFF
--- a/app/views/membership_mailer/creation_email.html.haml
+++ b/app/views/membership_mailer/creation_email.html.haml
@@ -35,7 +35,7 @@
           - @challenge.readings.each do |read|
             %tr
               %td
-                = read.date.strftime("%-m/%-d/%y")
+                = read.read_on.strftime("%-m/%-d/%y")
               %td
                 = read.chapter.book_name
                 = read.chapter.chapter_number

--- a/spec/controllers/member/memberships_controller_spec.rb
+++ b/spec/controllers/member/memberships_controller_spec.rb
@@ -46,7 +46,7 @@ describe Member::MembershipsController do
   end
 
   describe  'POST#create' do
-    let(:newchallenge){create(:challenge, owner: owner)}
+    let(:newchallenge){create(:challenge_with_readings, owner: owner)}
 
     it "redirects to the challenge page after joining as a logged in user" do
       somechallenge = create(:challenge)  #uses factorygirl


### PR DESCRIPTION
- View was calling Challenge.date, when date was actually changed to read_on.

In tests the view was silently failing and still constructing and sending the email
