### PR TITLE
Changed Default Settings for preferred_reading_hour and time_zone

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,7 @@ class User < ActiveRecord::Base
 
   #Callbacks
   #after_create :associate_statistics
+  before_save :set_default_values
 
   # autogenerate has_one associations for all the badge types
   Rails.application.eager_load!
@@ -88,5 +89,13 @@ class User < ActiveRecord::Base
 
       user.save!
     end
+  end
+
+  private
+
+  
+  def set_default_values
+    self.preferred_reading_hour ||= "3"
+    self.time_zone ||= "Central Time (US & Canada)"
   end
 end

--- a/db/migrate/20150713180844_remove_default_settings_from_users.rb
+++ b/db/migrate/20150713180844_remove_default_settings_from_users.rb
@@ -1,0 +1,6 @@
+class RemoveDefaultSettingsFromUsers < ActiveRecord::Migration
+  def change
+    change_column_default(:users, :preferred_reading_hour, nil)
+    change_column_default(:users, :time_zone, nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150708222833) do
+ActiveRecord::Schema.define(version: 20150713180844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,8 +185,8 @@ ActiveRecord::Schema.define(version: 20150708222833) do
   add_index "user_statistics", ["user_id"], name: "index_user_statistics_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "",    null: false
-    t.string   "encrypted_password",     default: "",    null: false
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -202,8 +202,8 @@ ActiveRecord::Schema.define(version: 20150708222833) do
     t.string   "uid"
     t.string   "name"
     t.string   "image"
-    t.string   "time_zone",              default: "EST"
-    t.integer  "preferred_reading_hour", default: 12
+    t.string   "time_zone"
+    t.integer  "preferred_reading_hour"
     t.string   "avatar_file_name"
     t.string   "avatar_content_type"
     t.integer  "avatar_file_size"


### PR DESCRIPTION
Removed the default settings from db to the user model in a call back for before_save because it's easier to change and find.
User model
before_save :set_default_values
Will set preffered_reading_hour and time_zone if none is provided.

Changed default from Abbreviation to actual wording because the dropdown in the profile page was not recognizing the abbreviation from the provided list.
