### PR TITLE
sidekiq email job retry to be false

### DIFF
--- a/app/workers/daily_email_worker.rb
+++ b/app/workers/daily_email_worker.rb
@@ -1,7 +1,7 @@
 class DailyEmailWorker
   include Sidekiq::Worker
   #if there is a problem with the email we don't want the worker retrying the job
-  sidekiq_options retry: 3
+  sidekiq_options retry: false
 
   def perform(readings, member)
     ReadingMailer.daily_reading_email(readings, member).deliver_now

--- a/app/workers/message_users_email_worker.rb
+++ b/app/workers/message_users_email_worker.rb
@@ -1,7 +1,7 @@
 class MessageUsersEmailWorker
   include Sidekiq::Worker
   #if there is a problem with the email we don't want the worker retrying the job
-  sidekiq_options retry: 3
+  sidekiq_options retry: false
 
   def perform(email_array, message, challenge_id)
     challenge = Challenge.find(challenge_id)

--- a/app/workers/new_auto_membership_email_worker.rb
+++ b/app/workers/new_auto_membership_email_worker.rb
@@ -1,7 +1,7 @@
 class NewAutoMembershipEmailWorker
   include Sidekiq::Worker
   #if there is a problem with the email we don't want the worker retrying the job
-  sidekiq_options retry: 3
+  sidekiq_options retry: false
 
   def perform(membership_id, password)
     MembershipMailer.auto_creation_email(membership_id, password).deliver_now

--- a/app/workers/new_challenge_email_worker.rb
+++ b/app/workers/new_challenge_email_worker.rb
@@ -1,7 +1,7 @@
 class NewChallengeEmailWorker
   include Sidekiq::Worker
   #if there is a problem with the email we don't want the worker retrying the job
-  sidekiq_options retry: 3
+  sidekiq_options retry: false
 
   def perform(challenge_id)
     ChallengeMailer.creation_email(challenge_id).deliver_now

--- a/app/workers/new_membership_email_worker.rb
+++ b/app/workers/new_membership_email_worker.rb
@@ -1,7 +1,7 @@
 class NewMembershipEmailWorker
   include Sidekiq::Worker
   #if there is a problem with the email we don't want the worker retrying the job
-  sidekiq_options retry: 3
+  sidekiq_options retry: false
 
   def perform(membership_id)
     MembershipMailer.creation_email(membership_id).deliver_now


### PR DESCRIPTION
Changed sidekiq option of retry jobs to be false for emails.  

According to http://railscasts.com/episodes/366-sidekiq, Ryan mentioned that if it is an email, we want to avoiding sending the same email twice, so he added the line `sidekiq_options retry: false`
