### PR TITLE
Challenge owner can no longer unsubscribe via email. 

### DIFF
--- a/app/views/member/memberships/unsubscribe.html.haml
+++ b/app/views/member/memberships/unsubscribe.html.haml
@@ -6,16 +6,6 @@ You are choosing to unsubscribe from the
   Bible Challenge.
 %br
 
-- if current_user == @membership.challenge.owner
-  %h6 
-    %strong
-      %u
-        WARNING: You are the owner of this Challenge!  
-      %br
-      %br
-        If you unsubscribe, the challenge itself will be deleted along with all the members and groups within it.
-      %p
-        Are you sure you want to unsubscribe?
 %br
 =button_to "Unsubscribe Me", member_membership_path(@membership,
                               user_email: @membership.user.email,

--- a/app/views/reading_mailer/daily_reading_email.html.haml
+++ b/app/views/reading_mailer/daily_reading_email.html.haml
@@ -36,5 +36,6 @@
         #{link_to 'Manage your notification preferences.', edit_user_url}
       %br
       %br
+      -unless @user == @membership.challenge.owner
         If for ANY reason you would like to opt-out of this bible reading challenge, simply click
         #{link_to 'Here', unsubscribe_member_membership_url(@membership.id, user_email: @user.email, user_token: @user.authentication_token)} here to be unsubscribed.

--- a/spec/features/user_unsubscribes_via_email_spec.rb
+++ b/spec/features/user_unsubscribes_via_email_spec.rb
@@ -19,22 +19,6 @@ feature 'User unsubscribes via email' do
     }.to change(Membership, :count).by(-1)
 
   end
-
-  scenario 'Owner unsubscribes from a challenge and in doing so, deletes the challenge altogether' do
-
-    user = create(:user)
-    challenge = create(:challenge, :with_readings, owner_id: user.id)
-    create(:membership, user: user, challenge: challenge)
-    ReadingMailer.daily_reading_email([challenge.readings.first.id], user.id).deliver_now
-
-    open_last_email
-    path = parse_email_for_link(current_email, "Here")# the link is Click *here* to unsubsubscribe
-    visit(path)
-    click_button("Unsubscribe Me")
-    expect(Challenge.all.size).to eq 0
-    expect(Membership.all.size).to eq 0
-
-  end
 end
 
 


### PR DESCRIPTION
What was done:

Challenge owner can unsubscribe via email, but essentially they are deleting the challenge altogether.  Warning signs are posted.
